### PR TITLE
Use environment variables

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,4 +34,4 @@ app.delete('/delete-note/:id', (req, res) => {
   })
 })
 
-app.listen(3000, () => console.log('Listening on 3000...'))
+app.listen(process.env.LISTEN_PORT, () => console.log('Listening on 3000...'))


### PR DESCRIPTION
Substituted the listen port number within index.js for a property of the process.env object in node, which can be set at runtime.